### PR TITLE
Chromium8 alternate bin

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,6 +38,17 @@ util/mac-install.sh
 
 On Linux, just run "make" again, and copy the created executables. I recommend copying "libffmpegsumo.so" from chromium/src/out/Debug for video tag support, as well as any other plugins you may want to include.
 
+==== Support:
+
+Our new mailing list is at http://groups.google.com/group/berkelium
+
+Before asking a question, search on google with "berkelium", which will also
+find discussions in the old list archives as well.
+If you can't find the answer in the archives, feel free to ask a question to
+the mailing list.
+
+The authors below should be used only as a last resort, or for private matters.
+
 ==== About the authors:
 
 Main contributors:

--- a/doc/index.doc
+++ b/doc/index.doc
@@ -35,4 +35,13 @@
  * <h3> Older Versions </h3>
  *  - See the <a href="/archive">archive directory</a> for older versions of this
  *    documentation.
+ *
+ * <h3> Mailing List and questions </h3>
+ *  - Subscribe to our new mailing list at
+ *    http://groups.google.com/group/berkelium
+ *  - Some questions can be answered with a quick google search (searches our
+ *    old mailing list, too) but if you're still stuck, feel free to ask.
+ *  - If you have private questions, you may contact one of the authors
+ *    included in the README.txt or the top of a source file, though we prefer
+ *    if you use the mailing list.
  */

--- a/include/berkelium/Berkelium.hpp
+++ b/include/berkelium/Berkelium.hpp
@@ -68,7 +68,14 @@ void BERKELIUM_EXPORT forkedProcessHook(
 void BERKELIUM_EXPORT forkedProcessHook(int argc, char **argv);
 #endif
 
-/** Iniitialize berkelium's global object.
+/** Initialize berkelium's global object, extended mode
+ *  \param homeDirectory  Just like Chrome's --user-data-dir command line flag.
+ *    If homeDirectory is null or empty, creates a temporary data directory.
+ *  \param berkeliumPath  Specify a custom directory to search berkelium binary
+ */
+bool BERKELIUM_EXPORT initEx(FileString homeDirectory, char *berkeliumPath);
+
+/** Initialize berkelium's global object.
  *  \param homeDirectory  Just like Chrome's --user-data-dir command line flag.
  *    If homeDirectory is null or empty, creates a temporary data directory.
  */

--- a/src/Berkelium.cpp
+++ b/src/Berkelium.cpp
@@ -31,19 +31,30 @@
  */
 
 #include "berkelium/Berkelium.hpp"
+#include "base/path_service.h"
+#include "base/file_util.h"
 #include "Root.hpp"
 
 namespace Berkelium {
 
 // See ForkedProcessHook.cpp for Berkelium::forkedProcessHook
 
-bool init (FileString homeDirectory) {
+bool initEx (FileString homeDirectory, char *berkeliumPath) {
+    if ( berkeliumPath != NULL ) {
+        FilePath subprocess = FilePath(berkeliumPath);
+        subprocess = subprocess.Append("berkelium");
+        PathService::Override(base::FILE_EXE, subprocess);
+    }
+
     new Root();
     if (!Root::getSingleton().init(homeDirectory)) {
         Root::destroy();
         return false;
     }
     return true;
+}
+bool init (FileString homeDirectory) {
+    return initEx(homeDirectory, NULL);
 }
 void destroy () {
     Root::destroy();


### PR DESCRIPTION
Hi guys,

I'm using berkelium inside Python extension, and one trouble i got is that the binary is searched from the argv[0] of the project... but since it's Python, he's trying to execute /usr/bin/python instead of changing to berkelium. And for subprocess path, he try to add berkelium in front of /usr/bin, but that's not where is located the binary :)

So i've added initEx, with a possibility to pass a custom path to search the berkelium binary. I hope you'll be ok with that :) And init is redirected on initEx. So it doesn't broke current examples.

Regards,

Mathieu
