### PR TITLE
Only the bin and lib directories get installed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,8 @@ IF(CHROME_FOUND)
           DESTINATION bin
           LIBRARY
           DESTINATION lib)
+  INSTALL(DIRECTORY include/berkelium
+      DESTINATION include)
   IF(NOT APPLE)
     INSTALL(FILES
           ${CHROMIUM_DATADIR}/chrome.pak


### PR DESCRIPTION
Only the bin and lib directories get installed, install the include directory also.

Tested on Linux Ubuntu 10.04+ 64-bit.
