### PR TITLE
Added message on singleton exception.

### DIFF
--- a/include/berkelium/Singleton.hpp
+++ b/include/berkelium/Singleton.hpp
@@ -40,7 +40,7 @@ template <class T> class AutoSingleton {
 public:
     static T& getSingleton() {
         if (sInstance.get()==NULL)  {
-            throw std::exception();
+            throw std::exception("Berkelium::AutoSingleton::getSingleton() : FAILED -> Instance not created!");
         }
         return *static_cast<T*>(sInstance.get());
     }


### PR DESCRIPTION
I've been hunting for this exception with no message for an hour. I have some try/catch with std::exception that makes gdb not break when this is thrown, because it is catch but there is no what() so I didn't knew where it came from. 
This is just an addition of message that state clearly where the exception comes from and why. 
Maybe the message could be enhanced, obviously.

I didn't compile this yet.
