### PR TITLE
Applied a patch from the mailing list, somewhat fixing a race condition.

### DIFF
--- a/src/WindowImpl.cpp
+++ b/src/WindowImpl.cpp
@@ -604,7 +604,6 @@ bool WindowImpl::OnMessageReceived(const IPC::Message& message) {
     return handled;
 }
 
-
 const GURL& WindowImpl::GetURL() const {
 	return mCurrentURL;
 }
@@ -615,12 +614,18 @@ void WindowImpl::DidStartLoading() {
         return;
 
     SetIsLoading(true);
-    evalInitialJavascript();
 
     if (mDelegate) {
         mDelegate->onLoadingStateChanged(this, true);
     }
 }
+
+void WindowImpl::DocumentAvailableInMainFrame( RenderViewHost *pRVH )
+{
+	evalInitialJavascript();
+	RenderViewHostDelegate::DocumentAvailableInMainFrame( pRVH );
+}
+
 void WindowImpl::DidStopLoading() {
     SetIsLoading(false);
 

--- a/src/WindowImpl.hpp
+++ b/src/WindowImpl.hpp
@@ -215,6 +215,7 @@ protected: /******* RenderViewHostDelegate *******/
 
     virtual void DidNavigate(RenderViewHost* render_view_host,
                              const ViewHostMsg_FrameNavigate_Params& params);
+    virtual void DocumentAvailableInMainFrame(RenderViewHost* render_view_host);
     virtual void UpdateState(RenderViewHost* render_view_host,
                              int32 page_id,
                              const std::string& state);


### PR DESCRIPTION
Hey guys,

This was posted on the mailing list quite a while ago, and I had run into a similar problem where the page was not having javascript executed on load.  The workaround of ignoring an alert() was not working for me either, I had to click a button that executed a javascript function, which would throw an error - However, clicking it a second time would always work.

This patch has eliminated that, although I read something about it may not be 100%, it's definitely a better start from where I was prior to this.  I hope this helps others as well.
