### PR TITLE
Berkelium should check if a glib thread isn't already running

### DIFF
--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -306,19 +306,22 @@ bool Root::init(FileString homeDirectory, FileString subprocessDirectory) {
     mErrorHandler = 0;
 
 #if defined(OS_LINUX)
-    g_thread_init(NULL);
-    // Glib type system initialization. Needed at least for gconf,
-    // used in net/proxy/proxy_config_service_linux.cc. Most likely
-    // this is superfluous as gtk_init() ought to do this. It's
-    // definitely harmless, so retained as a reminder of this
-    // requirement for gconf.
-    g_type_init();
-    // gtk_init() can change |argc| and |argv|.
-    char argv0data[] = "[Berkelium]";
-    char *argv0 = argv0data;
-    char **argv = &argv0;
-    int argc = 1;
-    gtk_init(&argc, &argv);
+    if (!g_thread_supported ()) // the client application might have already setup glib
+	{
+		g_thread_init(NULL);
+		// Glib type system initialization. Needed at least for gconf,
+		// used in net/proxy/proxy_config_service_linux.cc. Most likely
+		// this is superfluous as gtk_init() ought to do this. It's
+		// definitely harmless, so retained as a reminder of this
+		// requirement for gconf.
+		g_type_init();
+		// gtk_init() can change |argc| and |argv|.
+		char argv0data[] = "[Berkelium]";
+		char *argv0 = argv0data;
+		char **argv = &argv0;
+		int argc = 1;
+		gtk_init(&argc, &argv);
+    }
     SetUpGLibLogHandler();
 #endif
 


### PR DESCRIPTION
Most applications (like ours) might already have their threads running before initializing Berkelium.

This if is mandatory to avoid a crash if the application did the g_thead_init() before initalizing Berkelium.

I tested this in our application, all seems fine. Also I made sure if it's not Berkelium that initialized the thread, it shouldn't impose the main window title either (like it is doing when it will init the thread itself).
