### PR TITLE
Chromium11

### DIFF
--- a/patches/chromium_libpng_1.5.patch
+++ b/patches/chromium_libpng_1.5.patch
@@ -1,0 +1,37 @@
+--- chromium/third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	2010-08-24 17:47:39.000000000 -0700
++++ chromium/third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	2010-08-24 18:11:55.000000000 -0700
+@@ -224,11 +224,11 @@
+ {
+     png_structp png = m_reader->pngPtr();
+     png_infop info = m_reader->infoPtr();
+-    png_uint_32 width = png->width;
+-    png_uint_32 height = png->height;
++    png_uint_32 width = png_get_image_width(png, info);
++    png_uint_32 height = png_get_image_height(png, info);
+     
+     // Protect against large images.
+-    if (png->width > cMaxPNGSize || png->height > cMaxPNGSize) {
++    if (width > cMaxPNGSize || height > cMaxPNGSize) {
+         longjmp(JMPBUF(png), 1);
+         return;
+     }
+@@ -292,8 +292,7 @@
+ 
+     if (m_reader->decodingSizeOnly()) {
+         // If we only needed the size, halt the reader.     
+-        m_reader->setReadOffset(m_reader->currentBufferSize() - png->buffer_size);
+-        png->buffer_size = 0;
++        m_reader->setReadOffset(m_reader->currentBufferSize() - png_process_data_pause(png, 0/*do not save the data*/));
+     }
+ }
+ 
+@@ -315,7 +314,8 @@
+         // For PNGs, the frame always fills the entire image.
+         buffer.setRect(IntRect(IntPoint(), size()));
+ 
+-        if (m_reader->pngPtr()->interlaced)
++        if (png_get_interlace_type(m_reader->pngPtr(), m_reader->infoPtr())
++		!= PNG_INTERLACE_NONE)
+             m_reader->createInterlaceBuffer((m_reader->hasAlpha() ? 4 : 3) * size().width() * size().height());
+     }
+ 

--- a/patches/chromium_libpng_1.5.patch
+++ b/patches/chromium_libpng_1.5.patch
@@ -1,6 +1,30 @@
---- chromium/third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	2010-08-24 17:47:39.000000000 -0700
-+++ chromium/third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	2010-08-24 18:11:55.000000000 -0700
-@@ -224,11 +224,11 @@
+Index: third_party/WebKit/Source/WebCore/platform/image-encoders/skia/PNGImageEncoder.cpp
+===================================================================
+--- third_party/WebKit/Source/WebCore/platform/image-encoders/skia/PNGImageEncoder.cpp	(revision 86868)
++++ third_party/WebKit/Source/WebCore/platform/image-encoders/skia/PNGImageEncoder.cpp	(working copy)
+@@ -43,7 +43,7 @@
+ 
+ static void writeOutput(png_structp png, png_bytep data, png_size_t size)
+ {
+-    static_cast<Vector<unsigned char>*>(png->io_ptr)->append(data, size);
++    static_cast<Vector<unsigned char>*>(png_get_io_ptr(png))->append(data, size);
+ }
+ 
+ static void preMultipliedBGRAtoRGBA(const SkPMColor* input, int pixels, unsigned char* output)
+Index: third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+===================================================================
+--- third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	(revision 86868)
++++ third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	(working copy)
+@@ -228,7 +228,7 @@
+     int compressionType;
+     char* profile;
+     png_uint_32 profileLength;
+-    if (png_get_iCCP(png, info, &profileName, &compressionType, &profile, &profileLength)) {
++    if (png_get_iCCP(png, info, &profileName, &compressionType, (png_byte **)&profile, &profileLength)) {
+         ColorProfile colorProfile;
+         colorProfile.append(profile, profileLength);
+         return colorProfile;
+@@ -241,11 +241,11 @@
  {
      png_structp png = m_reader->pngPtr();
      png_infop info = m_reader->infoPtr();
@@ -15,7 +39,7 @@
          longjmp(JMPBUF(png), 1);
          return;
      }
-@@ -292,8 +292,7 @@
+@@ -319,8 +319,7 @@
  
      if (m_reader->decodingSizeOnly()) {
          // If we only needed the size, halt the reader.     
@@ -25,13 +49,13 @@
      }
  }
  
-@@ -315,7 +314,8 @@
+@@ -343,7 +342,8 @@
          // For PNGs, the frame always fills the entire image.
-         buffer.setRect(IntRect(IntPoint(), size()));
+         buffer.setOriginalFrameRect(IntRect(IntPoint(), size()));
  
 -        if (m_reader->pngPtr()->interlaced)
 +        if (png_get_interlace_type(m_reader->pngPtr(), m_reader->infoPtr())
 +		!= PNG_INTERLACE_NONE)
              m_reader->createInterlaceBuffer((m_reader->hasAlpha() ? 4 : 3) * size().width() * size().height());
      }
- 
+

--- a/patches/chromium_libpng_1.5.patch
+++ b/patches/chromium_libpng_1.5.patch
@@ -11,20 +11,23 @@ Index: third_party/WebKit/Source/WebCore/platform/image-encoders/skia/PNGImageEn
  }
  
  static void preMultipliedBGRAtoRGBA(const SkPMColor* input, int pixels, unsigned char* output)
-Index: third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+Index: /home/matt/src/berkelium/build/chromium/src/third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
 ===================================================================
---- third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	(revision 86868)
-+++ third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	(working copy)
-@@ -228,7 +228,7 @@
+--- /home/matt/src/berkelium/build/chromium/src/third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	(revision 86868)
++++ /home/matt/src/berkelium/build/chromium/src/third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp	(working copy)
+@@ -228,7 +228,11 @@
      int compressionType;
      char* profile;
      png_uint_32 profileLength;
--    if (png_get_iCCP(png, info, &profileName, &compressionType, &profile, &profileLength)) {
++#if PNG_LIBPNG_VER_MAJOR >= 1 && PNG_LIBPNG_VER_MINOR >= 5
 +    if (png_get_iCCP(png, info, &profileName, &compressionType, (png_byte **)&profile, &profileLength)) {
++#else
+     if (png_get_iCCP(png, info, &profileName, &compressionType, &profile, &profileLength)) {
++#endif
          ColorProfile colorProfile;
          colorProfile.append(profile, profileLength);
          return colorProfile;
-@@ -241,11 +241,11 @@
+@@ -241,11 +245,11 @@
  {
      png_structp png = m_reader->pngPtr();
      png_infop info = m_reader->infoPtr();
@@ -39,17 +42,20 @@ Index: third_party/WebKit/Source/WebCore/platform/image-decoders/png/PNGImageDec
          longjmp(JMPBUF(png), 1);
          return;
      }
-@@ -319,8 +319,7 @@
+@@ -319,8 +323,12 @@
  
      if (m_reader->decodingSizeOnly()) {
          // If we only needed the size, halt the reader.     
--        m_reader->setReadOffset(m_reader->currentBufferSize() - png->buffer_size);
--        png->buffer_size = 0;
++#if PNG_LIBPNG_VER_MAJOR >= 1 && PNG_LIBPNG_VER_MINOR >= 5
 +        m_reader->setReadOffset(m_reader->currentBufferSize() - png_process_data_pause(png, 0/*do not save the data*/));
++#else
+         m_reader->setReadOffset(m_reader->currentBufferSize() - png->buffer_size);
+         png->buffer_size = 0;
++#endif
      }
  }
  
-@@ -343,7 +342,8 @@
+@@ -343,7 +351,8 @@
          // For PNGs, the frame always fills the entire image.
          buffer.setOriginalFrameRect(IntRect(IntPoint(), size()));
  


### PR DESCRIPTION
This is just an added patch to work on boxes with >=libpng-1.5.  I work on a Gentoo box, and the default slot in portage is 1.5.8, we stop getting direct access to the png_struct.  This _should_ work on anything older as well, but I recommend testing it first.  I meant to send this in with my last pull request, but didn't think of it until I needed to build Berkelium on a new machine.

Thanks!
